### PR TITLE
Add Cauchy–Green eigenvalue and stretching diagnostics

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -22,6 +22,10 @@ FTLE_from_particles
 FTLE_from_particles!
 FTLE_from_particle_file
 FTLE_from_particle_file!
+cauchy_green_eigenvalues_over_grid
+cauchy_green_eigenvalues_over_grid!
+maximum_stretching_over_grid
+maximum_stretching_over_grid!
 ```
 
 ## Fields and Plotting

--- a/src/FTLE_computations.jl
+++ b/src/FTLE_computations.jl
@@ -48,11 +48,90 @@ function displacement_gradient_matrix_central(plonds, platds, dist_km)
     return B
 end
 
-@inline function _largest_cauchy_green_eigenvalue(a, b, c, d)
+@inline function _cauchy_green_invariants(a, b, c, d)
     C11 = a*a + c*c
     C12 = a*b + c*d
     C22 = b*b + d*d
-    return (C11 + C22 + sqrt((C11 - C22)^2 + 4C12^2)) / 2
+    trC = C11 + C22
+    discr = sqrt((C11 - C22)^2 + 4C12^2)
+    return trC, discr
+end
+
+@inline function _cauchy_green_eigenvalues(a, b, c, d)
+    trC, discr = _cauchy_green_invariants(a, b, c, d)
+    λmax = (trC + discr) / 2
+    λmin = max((trC - discr) / 2, zero(λmax))
+    return λmin, λmax
+end
+
+@inline _largest_cauchy_green_eigenvalue(a, b, c, d) = last(_cauchy_green_eigenvalues(a, b, c, d))
+
+"""
+    cauchy_green_eigenvalues_over_grid!(λmin_grid, λmax_grid, B)
+
+Compute the eigenvalues of the right Cauchy-Green deformation tensor `B'B` at
+each grid point and write them to `λmin_grid` and `λmax_grid`.
+
+This low-allocation diagnostic complements FTLE: `sqrt(λmax)` is the largest
+finite-time stretching factor, while `sqrt(λmin)` is the smallest. Values are
+clamped at zero only for the smaller eigenvalue to avoid tiny negative roundoff
+from nearly singular deformations.
+"""
+function cauchy_green_eigenvalues_over_grid!(λmin_grid, λmax_grid, B)
+    Ngpoints = size(B, 3)
+    length(λmin_grid) == Ngpoints || throw(DimensionMismatch("λmin_grid must have length $Ngpoints"))
+    length(λmax_grid) == Ngpoints || throw(DimensionMismatch("λmax_grid must have length $Ngpoints"))
+
+    @inbounds for k in 1:Ngpoints
+        λmin, λmax = _cauchy_green_eigenvalues(B[1, 1, k], B[1, 2, k], B[2, 1, k], B[2, 2, k])
+        λmin_grid[k] = λmin
+        λmax_grid[k] = λmax
+    end
+
+    return λmin_grid, λmax_grid
+end
+
+"""
+    cauchy_green_eigenvalues_over_grid(B)
+
+Allocating companion to [`cauchy_green_eigenvalues_over_grid!`](@ref). Returns
+`λmin_grid, λmax_grid`.
+"""
+function cauchy_green_eigenvalues_over_grid(B)
+    Ngpoints = size(B, 3)
+    λmin_grid = Vector{Float64}(undef, Ngpoints)
+    λmax_grid = Vector{Float64}(undef, Ngpoints)
+    return cauchy_green_eigenvalues_over_grid!(λmin_grid, λmax_grid, B)
+end
+
+"""
+    maximum_stretching_over_grid!(stretching_grid, B)
+
+Compute the largest finite-time stretching factor `sqrt(λmax(B'B))` at each
+grid point. This is equivalent to `exp(abs(T) * FTLE)` for nonzero integration
+time `T`, but remains a purely kinematic deformation diagnostic that does not
+require a time scale.
+"""
+function maximum_stretching_over_grid!(stretching_grid, B)
+    Ngpoints = size(B, 3)
+    length(stretching_grid) == Ngpoints || throw(DimensionMismatch("stretching_grid must have length $Ngpoints"))
+
+    @inbounds for k in 1:Ngpoints
+        λmax = _largest_cauchy_green_eigenvalue(B[1, 1, k], B[1, 2, k], B[2, 1, k], B[2, 2, k])
+        stretching_grid[k] = sqrt(λmax)
+    end
+
+    return stretching_grid
+end
+
+"""
+    maximum_stretching_over_grid(B)
+
+Allocating companion to [`maximum_stretching_over_grid!`](@ref).
+"""
+function maximum_stretching_over_grid(B)
+    stretching_grid = Vector{Float64}(undef, size(B, 3))
+    return maximum_stretching_over_grid!(stretching_grid, B)
 end
 
 function FTLE_over_grid!(FTLE_grid, B, T)
@@ -457,6 +536,10 @@ function FTLE_from_particle_file(
 end
 
 export Re
+export cauchy_green_eigenvalues_over_grid!
+export cauchy_green_eigenvalues_over_grid
+export maximum_stretching_over_grid!
+export maximum_stretching_over_grid
 export FTLE_from_particles!
 export FTLE_from_particles
 export FTLE_from_particle_file!

--- a/src/SpeedyWeatherFTLE.jl
+++ b/src/SpeedyWeatherFTLE.jl
@@ -26,6 +26,10 @@ export FTLEResult
 export final_ftle
 export final_ftle_field
 export ftle_field
+export cauchy_green_eigenvalues_over_grid!
+export cauchy_green_eigenvalues_over_grid
+export maximum_stretching_over_grid!
+export maximum_stretching_over_grid
 export FTLE_from_particles!
 export FTLE_from_particles
 export FTLE_from_particle_file!

--- a/test/FTLE_computations.jl
+++ b/test/FTLE_computations.jl
@@ -58,6 +58,36 @@ using Test
         @test all(isnan, SpeedyWeatherFTLE.FTLE_over_grid(B, 0.0))
     end
 
+    @testset "Cauchy-Green stretching diagnostics" begin
+        B = exact_flow_maps(linear_systems, duration, 1)
+        expected_λmax = [maximum(svdvals(B[:, :, i]))^2 for i in axes(B, 3)]
+        expected_λmin = [minimum(svdvals(B[:, :, i]))^2 for i in axes(B, 3)]
+        expected_stretching = sqrt.(expected_λmax)
+
+        λmin = fill(NaN, length(linear_systems))
+        λmax = fill(NaN, length(linear_systems))
+        stretching = fill(NaN, length(linear_systems))
+
+        returned_λmin, returned_λmax = cauchy_green_eigenvalues_over_grid!(λmin, λmax, B)
+        @test returned_λmin === λmin
+        @test returned_λmax === λmax
+        @test λmin ≈ expected_λmin rtol=1e-12 atol=1e-12
+        @test λmax ≈ expected_λmax rtol=1e-12 atol=1e-12
+
+        allocated_λmin, allocated_λmax = cauchy_green_eigenvalues_over_grid(B)
+        @test allocated_λmin ≈ expected_λmin rtol=1e-12 atol=1e-12
+        @test allocated_λmax ≈ expected_λmax rtol=1e-12 atol=1e-12
+
+        @test maximum_stretching_over_grid!(stretching, B) === stretching
+        @test stretching ≈ expected_stretching rtol=1e-12 atol=1e-12
+        @test maximum_stretching_over_grid(B) ≈ expected_stretching rtol=1e-12 atol=1e-12
+        @test log.(stretching) ./ duration ≈ SpeedyWeatherFTLE.FTLE_over_grid(B, duration) rtol=1e-12 atol=1e-12
+
+        @test_throws DimensionMismatch cauchy_green_eigenvalues_over_grid!(λmin[1:end-1], λmax, B)
+        @test_throws DimensionMismatch cauchy_green_eigenvalues_over_grid!(λmin, λmax[1:end-1], B)
+        @test_throws DimensionMismatch maximum_stretching_over_grid!(stretching[1:end-1], B)
+    end
+
     @testset "wrapped longitude displacement gradient" begin
         # East-west particles can straddle 0/360 degrees; their central difference
         # should still reconstruct an identity deformation at release time.


### PR DESCRIPTION
### Motivation
- Provide low-allocation diagnostics that complement FTLE by exposing the right Cauchy–Green tensor eigenvalues and the maximum finite-time stretching factor from deformation-gradient fields.
- Give users kinematic deformation metrics that do not require a time scale and improve observability for Lagrangian diagnostics and workflows.
- Add unit coverage and documentation so these helpers can be consumed from the package API.

### Description
- Implemented `_cauchy_green_invariants`, `_cauchy_green_eigenvalues`, `cauchy_green_eigenvalues_over_grid!`, `cauchy_green_eigenvalues_over_grid`, `maximum_stretching_over_grid!`, and `maximum_stretching_over_grid` in `src/FTLE_computations.jl`; the small helper clamps the smaller eigenvalue at zero to avoid tiny negative roundoff on nearly singular deformations.
- Kept a single-element, low-allocation API pattern with in-place and allocating variants and exposed a `_largest_cauchy_green_eigenvalue` wrapper for reuse by the stretching helper.
- Exported the new symbols from `src/SpeedyWeatherFTLE.jl` and added entries to the docs API index at `docs/src/api.md`.
- Added unit tests in `test/FTLE_computations.jl` that validate eigenvalues and stretching against analytic linear-flow maps, check consistency with FTLE (`log(stretching)/T`), and exercise dimension validation error paths.

### Testing
- Ran repository checks (`git diff --check`) and committed the changes as `Add Cauchy-Green stretching diagnostics`.
- Added unit tests under `test/FTLE_computations.jl`, but running `julia --project=. -e 'using Pkg; Pkg.test()'` could not be performed in this environment because `julia` is not installed here, so the automated test run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a452940b8088333833d5153c2706838)